### PR TITLE
Use the Sphinx RTD theme to give people familiarity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Sphinx==1.3.1
 sphinx-autobuild==0.5.2
+sphinx_rtd_theme==0.1.9

--- a/source/conf.py
+++ b/source/conf.py
@@ -108,7 +108,16 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+import os
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Hackery because
https://docs.readthedocs.org/en/latest/theme.html#how-do-i-use-this-locally-and-on-read-the-docs

> Unfortunately, at the moment Read the Docs can’t handle importing
> sphinx_rtd_theme, so if you try to use that theme for building on both
> Read the Docs and locally, it will fail.

(Sadness)
