### PR TITLE
Add notes on how deployment works with Travis and IRL People

### DIFF
--- a/source/infrastructure.rst
+++ b/source/infrastructure.rst
@@ -91,3 +91,12 @@ Years prior to 2015 have A records pointing them to a server kindly hosted by Ze
 Passwords
 ---------
 Account passwords are currently in a 1Password vault that only George has access to. This needs to be improved.
+
+
+Website Deployment
+------------------
+The website can be built and deployed locally by running ``make deploy``. However this is not ideal when using a Pull Request workflow since it requires someone to have a working environment and thus TravisCI has been set up to deploy changes made to master.
+
+The ``deploy.sh`` script deals with checking whether it's a person or Travis deploying the site. A person requires no additional authentication (GitHub already knows who you are). Travis requires setting the ``GH_TOKEN`` in the build env. To do this create a `Personal Access Token on GitHub <https://github.com/settings/tokens>`_ then create the ``GH_TOKEN`` key pair on the `Travis settings page <https://travis-ci.org/PyconUK/2016.pyconuk.org/settings>`_.
+
+Note: This is tied to a single user on GitHub, however any other GitHub user with valid permissions can replace the key on Travis.

--- a/source/infrastructure.rst
+++ b/source/infrastructure.rst
@@ -97,6 +97,4 @@ Website Deployment
 ------------------
 The website can be built and deployed locally by running ``make deploy``. However this is not ideal when using a Pull Request workflow since it requires someone to have a working environment and thus TravisCI has been set up to deploy changes made to master.
 
-The ``deploy.sh`` script deals with checking whether it's a person or Travis deploying the site. A person requires no additional authentication (GitHub already knows who you are). Travis requires setting the ``GH_TOKEN`` in the build env. To do this create a `Personal Access Token on GitHub <https://github.com/settings/tokens>`_ then create the ``GH_TOKEN`` key pair on the `Travis settings page <https://travis-ci.org/PyconUK/2016.pyconuk.org/settings>`_.
-
-Note: This is tied to a single user on GitHub, however any other GitHub user with valid permissions can replace the key on Travis.
+For more details on this see `the website readme <https://github.com/PyconUK/2016.pyconuk.org#deployment>`_.


### PR DESCRIPTION
This explains how Travis is configured so it can deploy the website and how to recreate the necessary credentials if we need to.
