### PR TITLE
Add links to pretix and pretalix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build Documentation
+
+on:
+  pull_request:
+    branches:
+    - main
+  push:
+    branches:
+    - main
+
+jobs:
+  docs:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: 'actions/checkout@v3'
+
+    - uses: 'actions/setup-python@v4'
+      with:
+        python-version: '3.10'
+
+    - run: |
+        set -e
+        python --version
+        python -m pip install --upgrade pip tox
+      name: Setup Environment
+
+    - id: build
+      run: |
+        tox -e build
+      name: Run Tox
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.env
 /.tox
 /build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Sphinx==1.3.1
-sphinx-autobuild==0.5.2
-sphinx_rtd_theme==0.1.9
-livereload==2.4.0
+Sphinx
+sphinx-autobuild
+sphinx_rtd_theme

--- a/source/schedule.rst
+++ b/source/schedule.rst
@@ -1,12 +1,13 @@
 Schedule
 ========
 
-We've committed to the following things, which need to find their way onto the
-schedule:
+TDB
 
-- Django Girls workshop (all day Thursday)
-- Teachers' day (all day Friday)
-- Children's day (all day Saturday)
-- A welcome session for first-time attendees (Friday morning)
-- The PyCon UK Society's AGM
-- Code4Research track (Sat, Sun and sprints on Monday)
+Pretalix
+--------
+
+Our CfP process and schedule is managed through `Pretalix <https://pretalx.com/p/about/>`_
+
+The management page for this year's event is `here <https://pretalx.com/orga/event/pyconuk-2023/>`_
+
+

--- a/source/tickets.rst
+++ b/source/tickets.rst
@@ -25,40 +25,9 @@ about the following, but make responses optional:
 * Age
 
 
-Tito
-====
+Pretix
+------
 
-We're selling tickets through `Tito <http://ti.to>`_.
+We're selling tickets through `Pretix <https://pretix.eu>`_.
 
-The tickets page is `here <https://ti.to/pyconuk/2016>`_.
-
-Refunding tickets
------------------
-
-We will offer a full refund on tickets until 1st September, and a 50% refund thereafter.
-
-To refund a ticket from the `Tito admin interface <https://ti.to/pyconuk/2016/admin/>`_:
-
-* Click "Orders", search for the ticket-holder's name
-* Click "Cancel this order"
-* Click "Yes" when asked if you're sure
-* Click "Refund via Stripe"
-
-Upgrading tickets
------------------
-
-We allow people to upgrade their tickets through their purchase of a `Ticket Upgrade <http://2016.pyconuk.org/tickets/upgrading/>`_ ticket.
-
-To process a Ticket Upgrade via the `Tito admin interface <https://ti.to/pyconuk/2016/admin/>`_, you find the original ticket, update its type, and then void the Ticket Upgrade.  In detail:
-
-* Click "Attendees"
-* Find the relevant Ticket Upgrade ticket
-  * Tickets can be filtered by type if required
-  * This should have the number of the original ticket that needs to be upgraded
-* Find the original ticket via its ticket number
-* Click "Edit attendee details"
-* Change the ticket type appropriately
-* Add "upgraded" as a tag
-* Save the ticket
-* Find the Ticket Upgrade ticket again
-* Click "Void ticket", then "Confirm void", then "No" (in answer to the question about refunds)
+The tickets page for this year's event is `here <https://pretix.eu/control/event/pyconuk/pyconuk-2023/>`_.


### PR DESCRIPTION
A simple PR to get things going again 

- Relaxes version bounds in `requirements.txt` so we pull in updated packages.
- Add links to pretix, pretalix and current events in the respective systems
- Simple GitHub actions workflow